### PR TITLE
feat(homepage): modernize with AI-forward services

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2,6 +2,8 @@
 
 @config './tailwind.config.js';
 
+[x-cloak] { display: none !important; }
+
 .hero-grid {
   background-image:
     linear-gradient(rgba(99, 102, 241, 0.08) 1px, transparent 1px),

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,3 +1,20 @@
 @import "tailwindcss";
 
 @config './tailwind.config.js';
+
+.hero-grid {
+  background-image:
+    linear-gradient(rgba(99, 102, 241, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99, 102, 241, 0.08) 1px, transparent 1px);
+  background-size: 60px 60px;
+}
+
+.hero-gradient-text {
+  animation: gradient-shift 6s ease-in-out infinite;
+  background-size: 200% auto;
+}
+
+@keyframes gradient-shift {
+  0%, 100% { background-position: 0% center; }
+  50% { background-position: 100% center; }
+}

--- a/data/founders.yml
+++ b/data/founders.yml
@@ -1,5 +1,5 @@
 - name: Vincent Link
-  position: Co-Founder
+  position: Co-Founder & Geschäftsführer
   description: |
     Herausforderungen motivieren mich, vor allem beim Entwickeln von einfachen Lösungen für komplexe Probleme!
   github: linkvt
@@ -7,7 +7,7 @@
   homepage: https://www.linkvt.de
   image: images/pages/home/vincent.jpg
 - name: Eduard Marbach
-  position: Co-Founder
+  position: Co-Founder & Geschäftsführer
   description: Hi! Ich bin schon immer begeistert mit Technologien aller Art und versuche mich stets weiterzubilden.
   github: BlackDark
   linkedin: eduard-marbach-716445134

--- a/data/skills.yml
+++ b/data/skills.yml
@@ -1,4 +1,31 @@
-- title: "Cloud"
+- title: "AI Guidance & Strategie"
+  featured_image: {}
+  icon: fa-solid fa-brain
+  description: Ihr wollt KI in Eurem Unternehmen sinnvoll einsetzen, wisst aber nicht wo anfangen? Wir begleiten Euch von der strategischen Planung über die Toolauswahl bis zur erfolgreichen Integration in bestehende Prozesse — pragmatisch und auf Eure Bedürfnisse zugeschnitten.
+  tags:
+    - KI-Strategie & Roadmap
+    - Toolauswahl und Evaluation
+    - Prozessoptimierung durch KI
+    - ROI-Analyse und Use-Case Bewertung
+- title: "AI Workshops & Schulungen"
+  featured_image: {}
+  icon: fa-solid fa-chalkboard-user
+  description: In unseren intensiven Workshops lernt Ihr den produktiven Umgang mit den neuesten KI-Tools. Von Prompt-Engineering über Code-Assistenten bis hin zu maßgeschneiderten Workflows — Euer Team wird fit für die KI-gestützte Arbeitswelt.
+  tags:
+    - "Tools: ChatGPT, Claude, Copilot, Cursor, v0"
+    - Prompt-Engineering & Best Practices
+    - KI-gestützte Softwareentwicklung
+    - Hands-On mit realen Use-Cases
+- title: "AI Agents & Workflows"
+  featured_image: {}
+  icon: fa-solid fa-robot
+  description: Wir entwickeln maßgeschneiderte KI-Agenten und automatisierte Workflows für Euer Unternehmen. Von MCP-Integrationen über benutzerdefinierte Agents bis hin zu komplexen Automatisierungspipelines — wir bringen KI dahin, wo sie echten Mehrwert schafft.
+  tags:
+    - Custom AI Agents & Assistenten
+    - MCP Server & Tool-Integrationen
+    - Workflow-Automatisierung
+    - RAG, Knowledge Bases & Embeddings
+- title: "Cloud & Infrastructure"
   featured_image: {}
   icon: fa-brands fa-aws
   description: Wir helfen Euch beim Aufsetzen und Weiterentwickeln Eures Cloud-Setups. Ob Ihr noch ganz am Anfang steht und die ersten AWS-Accounts anlegt, Eure Apps in Containern deployt oder schon Serverless unterwegs seid; wir unterstützen in jedem Bereich.
@@ -25,11 +52,3 @@
     - Containerisierung Eurer Apps
     - Monitoring, Logging & Alerting
     - Ohne Vendor-Lock-In
-- title: "Workshops & Schulungen"
-  featured_image: {}
-  icon: fa-solid fa-graduation-cap
-  description: Wir sehen uns als Entwicklungspartner und wollen unser Know-How an Eure Entwickler weitergeben. Wollt Ihr einen Überblick über ein Themengebiet oder einen Deep-Dive mit realistischen Aufgaben, dann gebt uns Bescheid!
-  tags:
-    - Trainings vor Ort und Remote
-    - Workshops mit praktischen Aufgaben
-    - Deep-Dives in allen Themen unseres Portfolios

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -17,7 +17,8 @@ markup:
 
 params:
   author: raydak GmbH
-  description: Home
+  homeTitle: "AI Consulting, Workshops & Entwicklung aus Stuttgart"
+  description: "raydak GmbH — AI Consulting, Workshops, Agent-Entwicklung, Cloud & DevOps aus Stuttgart. Wir machen Euer Team AI-ready."
   shortTitle: raydak
   footer:
     links:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,143 +1,109 @@
 {{ define "main" }}
   <main>
-    <div class="bg-gray-200 dark:bg-gray-900">
-      <div class="mx-auto max-w-screen-xl px-4 py-8">
-        <div class="mb-8 grid items-center gap-8 sm:mb-0 ">
-          <div class="col-span-6 px-4 text-center sm:mb-6 lg:mb-0">
-            <h1
-              class="mb-2 text-4xl font-extrabold leading-none tracking-tight text-gray-900 dark:text-white md:text-5xl xl:text-6xl"
-            >
-              Entwicklung und Consulting
-            </h1>
-            <h2
-              class="pb-2 text-3xl font-light text-gray-800 dark:text-gray-300 md:text-4xl"
-            >
-              Schnell und Flexibel
-            </h2>
-            <a
-              href="{{ relref . "#contact" }}"
-              class="mx-auto inline-block space-x-4 py-4"
-            >
-              <span
-                class="mx-auto mb-2 block max-w-fit rounded bg-indigo-500 px-2.5 py-1 text-sm font-bold text-gray-50 md:min-w-fit"
-              >
-                Schreib uns!
-              </span>
+    <!-- Hero -->
+    <div class="relative overflow-hidden bg-gray-950">
+      <div class="absolute inset-0 bg-gradient-to-br from-indigo-900/40 via-gray-950 to-purple-900/30"></div>
+      <div class="hero-grid absolute inset-0 opacity-15"></div>
+      <div class="relative mx-auto max-w-screen-xl px-4 py-20 sm:py-28 lg:py-36">
+        <div class="mx-auto max-w-4xl text-center">
+          <div class="mb-6 inline-flex items-center gap-2 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-4 py-1.5 text-sm font-medium text-indigo-300">
+            <i class="fa-solid fa-sparkles"></i>
+            AI-First Consulting &amp; Entwicklung
+          </div>
+          <h1 class="mb-4 text-4xl font-extrabold leading-tight tracking-tight text-white md:text-6xl xl:text-7xl">
+            Wir machen Euer Team
+            <span class="hero-gradient-text bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">AI-ready</span>
+          </h1>
+          <p class="mx-auto mb-10 max-w-2xl text-lg text-gray-300 md:text-xl">
+            Von strategischer KI-Beratung über intensive Workshops bis hin zu maßgeschneiderten AI Agents und Cloud-Infrastruktur — wir begleiten Euch auf dem Weg in die KI-gestützte Zukunft.
+          </p>
+          <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <a href="{{ relref . "#contact" }}" class="inline-flex items-center gap-2 rounded-lg bg-indigo-500 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-indigo-500/25 transition hover:bg-indigo-400 hover:shadow-indigo-500/40">
+              <i class="fa-solid fa-envelope"></i>
+              Jetzt Kontakt aufnehmen
             </a>
-            <p
-              class="mx-auto mb-6 max-w-xl font-normal text-gray-900 dark:text-gray-50 md:text-lg xl:mb-2 xl:text-xl"
-            >
-              Wir kennen die aktuellsten Trends und Technologie-Stacks und
-              wissen, wie man damit effiziente und performante Systeme baut. Wir
-              entwickeln selbst, geben unser Wissen aber auch gerne beratend und
-              in Workshops weiter. Interessiert?
-            </p>
+            <a href="{{ relref . "#services" }}" class="inline-flex items-center gap-2 rounded-lg border border-gray-600 px-8 py-3.5 text-base font-semibold text-gray-300 transition hover:border-gray-400 hover:text-white">
+              Unsere Services
+              <i class="fa-solid fa-arrow-down"></i>
+            </a>
+          </div>
+        </div>
+
+        <!-- Highlights -->
+        <div class="mx-auto mt-16 grid max-w-4xl grid-cols-2 gap-4 sm:mt-20 md:grid-cols-4">
+          <div class="rounded-xl border border-gray-800 bg-gray-900/60 px-4 py-5 text-center backdrop-blur">
+            <div class="text-2xl font-bold text-indigo-400">AI</div>
+            <div class="mt-1 text-sm text-gray-400">Guidance &amp; Strategie</div>
+          </div>
+          <div class="rounded-xl border border-gray-800 bg-gray-900/60 px-4 py-5 text-center backdrop-blur">
+            <div class="text-2xl font-bold text-purple-400">Workshops</div>
+            <div class="mt-1 text-sm text-gray-400">Hands-On Training</div>
+          </div>
+          <div class="rounded-xl border border-gray-800 bg-gray-900/60 px-4 py-5 text-center backdrop-blur">
+            <div class="text-2xl font-bold text-pink-400">Agents</div>
+            <div class="mt-1 text-sm text-gray-400">MCP &amp; Workflows</div>
+          </div>
+          <div class="rounded-xl border border-gray-800 bg-gray-900/60 px-4 py-5 text-center backdrop-blur">
+            <div class="text-2xl font-bold text-emerald-400">Cloud</div>
+            <div class="mt-1 text-sm text-gray-400">DevOps &amp; K8s</div>
           </div>
         </div>
       </div>
-      {{ partial "home/team" . }}
     </div>
+
+    {{ partial "home/team" . }}
 
     <!-- Wie helfen wir -->
     <div class="relative my-4">
-      <div
-        class="px-4 lg:px-8 lg:mx-auto lg:grid lg:max-w-7xl lg:grid-cols-2 lg:items-start lg:gap-24"
-      >
+      <div class="px-4 lg:mx-auto lg:grid lg:max-w-7xl lg:grid-cols-2 lg:items-start lg:gap-24 lg:px-8">
         <div class="relative sm:py-8 lg:py-0">
-          <div
-            aria-hidden="true"
-            class="hidden sm:block lg:absolute lg:inset-y-0 lg:right-0 lg:w-screen"
-          >
-            <div
-              class="absolute inset-y-0 right-1/2 w-full rounded-r-3xl bg-gray-50 dark:bg-gray-900/10 lg:right-72"
-            ></div>
-            <svg
-              class="absolute top-8 left-1/2 -ml-3 lg:-right-8 lg:left-auto lg:top-12"
-              width="404"
-              height="392"
-              fill="none"
-              viewBox="0 0 404 392"
-              loading="lazy"
-            >
+          <div aria-hidden="true" class="hidden sm:block lg:absolute lg:inset-y-0 lg:right-0 lg:w-screen">
+            <div class="absolute inset-y-0 right-1/2 w-full rounded-r-3xl bg-gray-50 dark:bg-gray-900/10 lg:right-72"></div>
+            <svg class="absolute top-8 left-1/2 -ml-3 lg:-right-8 lg:left-auto lg:top-12" width="404" height="392" fill="none" viewBox="0 0 404 392" loading="lazy">
               <defs>
-                <pattern
-                  id="02f20b47-fd69-4224-a62a-4c9de5c763f7"
-                  x="0"
-                  y="0"
-                  width="20"
-                  height="20"
-                  patternUnits="userSpaceOnUse"
-                >
-                  <rect
-                    x="0"
-                    y="0"
-                    width="4"
-                    height="4"
-                    class="text-gray-200 dark:text-gray-900/60"
-                    fill="currentColor"
-                  />
+                <pattern id="02f20b47-fd69-4224-a62a-4c9de5c763f7" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+                  <rect x="0" y="0" width="4" height="4" class="text-gray-200 dark:text-gray-900/60" fill="currentColor" />
                 </pattern>
               </defs>
-              <rect
-                width="404"
-                height="392"
-                fill="url(#02f20b47-fd69-4224-a62a-4c9de5c763f7)"
-              />
+              <rect width="404" height="392" fill="url(#02f20b47-fd69-4224-a62a-4c9de5c763f7)" />
             </svg>
           </div>
-          <div
-            class="relative mx-auto max-w-md py-6 sm:max-w-3xl lg:max-w-none lg:py-20"
-          >
+          <div class="relative mx-auto max-w-md py-6 sm:max-w-3xl lg:max-w-none lg:py-20">
             <div class="relative overflow-hidden rounded-2xl shadow-xl">
               {{ $banner := resources.GetMatch "images/pages/home/banner_1.jpg" }}
               {{ $banner_resized := ($banner.Resize "1000x webp") }}
-              <img
-                src="{{ $banner_resized.RelPermalink }}"
-                alt="Generic Stockphoto"
-                class="rounded-lg object-cover shadow-xl"
-                loading="lazy"
-              />
-              <div
-                class="absolute inset-0 bg-indigo-300 mix-blend-multiply"
-              ></div>
-              <div
-                class="absolute inset-0 bg-gradient-to-t from-indigo-600 opacity-80"
-              ></div>
+              <img src="{{ $banner_resized.RelPermalink }}" alt="raydak Team bei der Arbeit" class="rounded-lg object-cover shadow-xl" loading="lazy" />
+              <div class="absolute inset-0 bg-indigo-300 mix-blend-multiply"></div>
+              <div class="absolute inset-0 bg-gradient-to-t from-indigo-600 opacity-80"></div>
             </div>
           </div>
         </div>
         <div class="relative mx-auto max-w-md sm:max-w-3xl">
-          <!-- Content area -->
           <div class="sm:pt-6 md:pt-12 lg:pt-20">
-            <h2
-              class="text-3xl font-bold capitalize tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl"
-            >
+            <h2 class="text-3xl font-bold capitalize tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl">
               Wie helfen wir Euch?
             </h2>
             <div class="mt-6 space-y-6 text-gray-900 dark:text-white">
               <p class="text-lg leading-7">
-                Wir haben ein breites Portfolio an Wissen in verschiedenen
-                Bereichen der IT. Fokus legen wir dabei auf die Cloud,
-                Kubernetes, DevOps und saubere Softwareentwicklung.
+                Wir vereinen tiefes Know-How in KI, Cloud und Softwareentwicklung. Ob Ihr eine KI-Strategie braucht, Euer Team in AI-Tools schulen wollt oder maßgeschneiderte Agents und Workflows benötigt — wir sind Euer Partner für die digitale Transformation.
               </p>
 
-              <div
-                class="mt-12 grid grid-cols-3 gap-4 md:grid-cols-3 lg:mt-0 lg:grid-cols-3"
-              >
-                <div
-                  class="col-span-1 flex justify-center rounded bg-gray-50 px-4 py-4 dark:bg-gray-300/10"
-                >
-                  <span class="text-xl font-bold"> Consulting </span>
+              <div class="mt-12 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:mt-0">
+                <div class="flex flex-col items-center justify-center rounded-lg bg-gray-50 px-3 py-4 dark:bg-gray-300/10">
+                  <i class="fa-solid fa-brain mb-2 text-xl text-indigo-500"></i>
+                  <span class="text-center text-sm font-bold">AI Guidance</span>
                 </div>
-                <div
-                  class="col-span-1 flex justify-center rounded bg-gray-50 px-4 py-4 dark:bg-gray-300/10"
-                >
-                  <span class="text-xl font-bold"> Workshops </span>
+                <div class="flex flex-col items-center justify-center rounded-lg bg-gray-50 px-3 py-4 dark:bg-gray-300/10">
+                  <i class="fa-solid fa-chalkboard-user mb-2 text-xl text-indigo-500"></i>
+                  <span class="text-center text-sm font-bold">Workshops</span>
                 </div>
-                <div
-                  class="col-span-1 flex justify-center rounded bg-gray-50 px-4 py-4 dark:bg-gray-300/10"
-                >
-                  <span class="text-xl font-bold"> Coding </span>
+                <div class="flex flex-col items-center justify-center rounded-lg bg-gray-50 px-3 py-4 dark:bg-gray-300/10">
+                  <i class="fa-solid fa-robot mb-2 text-xl text-indigo-500"></i>
+                  <span class="text-center text-sm font-bold">AI Agents</span>
+                </div>
+                <div class="flex flex-col items-center justify-center rounded-lg bg-gray-50 px-3 py-4 dark:bg-gray-300/10">
+                  <i class="fa-solid fa-cloud mb-2 text-xl text-indigo-500"></i>
+                  <span class="text-center text-sm font-bold">Cloud & DevOps</span>
                 </div>
               </div>
             </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,8 +14,8 @@
             Wir machen Euer Team
             <span class="hero-gradient-text bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">AI-ready</span>
           </h1>
-          <p class="mx-auto mb-10 max-w-2xl text-lg text-gray-300 md:text-xl">
-            Von strategischer KI-Beratung über intensive Workshops bis hin zu maßgeschneiderten AI Agents und Cloud-Infrastruktur — wir begleiten Euch auf dem Weg in die KI-gestützte Zukunft.
+          <p class="mx-auto mb-10 max-w-2xl text-lg text-gray-400 md:text-xl">
+            KI-Beratung · Workshops · AI Agents · Cloud & DevOps
           </p>
           <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a href="{{ relref . "#contact" }}" class="inline-flex items-center gap-2 rounded-lg bg-indigo-500 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-indigo-500/25 transition hover:bg-indigo-400 hover:shadow-indigo-500/40">
@@ -84,11 +84,11 @@
               Wie helfen wir Euch?
             </h2>
             <div class="mt-6 space-y-6 text-gray-900 dark:text-white">
-              <p class="text-lg leading-7">
-                Wir vereinen tiefes Know-How in KI, Cloud und Softwareentwicklung. Ob Ihr eine KI-Strategie braucht, Euer Team in AI-Tools schulen wollt oder maßgeschneiderte Agents und Workflows benötigt — wir sind Euer Partner für die digitale Transformation.
+              <p class="text-base leading-7 text-gray-600 dark:text-gray-300">
+                KI, Cloud und Softwareentwicklung — aus einer Hand. Euer Partner für die digitale Transformation.
               </p>
 
-              <div class="mt-12 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:mt-0">
+              <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
                 <div class="flex flex-col items-center justify-center rounded-lg bg-gray-50 px-3 py-4 dark:bg-gray-300/10">
                   <i class="fa-solid fa-brain mb-2 text-xl text-indigo-500"></i>
                   <span class="text-center text-sm font-bold">AI Guidance</span>

--- a/layouts/partials/home/contact.html
+++ b/layouts/partials/home/contact.html
@@ -1,40 +1,28 @@
 <div class="mx-auto mt-6 max-w-screen-xl px-4 pb-16" id="contact">
-  <div
-    class="relative overflow-hidden rounded-2xl bg-indigo-500 px-12 py-20 shadow-xl max-sm:px-6 max-sm:py-10"
-  >
+  <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-600 via-indigo-500 to-purple-600 px-12 py-20 shadow-2xl max-sm:px-6 max-sm:py-12">
     <div aria-hidden="true" class="absolute inset-0 -mt-72 sm:-mt-32 md:mt-0">
-      <svg
-        class="absolute inset-0 h-full w-full"
-        preserveAspectRatio="xMidYMid slice"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 1463 360"
-        loading="lazy"
-      >
-        <path
-          class="text-indigo-600 text-opacity-40"
-          fill="currentColor"
-          d="M-82.673 72l1761.849 472.086-134.327 501.315-1761.85-472.086z"
-        />
-        <path
-          class="text-indigo-600 text-opacity-40"
-          fill="currentColor"
-          d="M-217.088 544.086L1544.761 72l134.327 501.316-1761.849 472.086z"
-        />
+      <svg class="absolute inset-0 h-full w-full" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 1463 360" loading="lazy">
+        <path class="text-white/5" fill="currentColor" d="M-82.673 72l1761.849 472.086-134.327 501.315-1761.85-472.086z" />
+        <path class="text-white/5" fill="currentColor" d="M-217.088 544.086L1544.761 72l134.327 501.316-1761.849 472.086z" />
       </svg>
     </div>
     <div class="relative">
-      <div class="text-center">
+      <div class="mx-auto max-w-2xl text-center">
         <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-          Interesse? Schreib Uns!
+          Bereit für die KI-Zukunft?
         </h2>
+        <p class="mt-4 text-lg text-indigo-100">
+          Lasst uns gemeinsam herausfinden, wie KI und moderne Technologien Euer Business voranbringen. Kostenloses Erstgespräch — unverbindlich und konkret.
+        </p>
       </div>
-      <div class="mt-12 flex justify-center sm:mx-auto sm:flex ">
-        <a
-          href="mailto:hello@raydak.de"
-          class="rounded-md border-transparent bg-gray-900 px-10 py-3.5 text-base font-medium text-white shadow hover:bg-black focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-indigo-500"
-        >
-          <i class="fa fa-envelope"></i> hello@raydak.de
+      <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <a href="mailto:hello@raydak.de" class="inline-flex items-center gap-2 rounded-lg bg-white px-8 py-3.5 text-base font-semibold text-indigo-600 shadow-lg transition hover:bg-gray-100">
+          <i class="fa fa-envelope"></i>
+          hello@raydak.de
+        </a>
+        <a href="https://linkedin.com/company/raydak" target="_blank" rel="noopener" class="inline-flex items-center gap-2 rounded-lg border-2 border-white/30 px-8 py-3.5 text-base font-semibold text-white transition hover:border-white hover:bg-white/10">
+          <i class="fa-brands fa-linkedin"></i>
+          LinkedIn
         </a>
       </div>
     </div>

--- a/layouts/partials/home/contact.html
+++ b/layouts/partials/home/contact.html
@@ -11,8 +11,8 @@
         <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
           Bereit für die KI-Zukunft?
         </h2>
-        <p class="mt-4 text-lg text-indigo-100">
-          Lasst uns gemeinsam herausfinden, wie KI und moderne Technologien Euer Business voranbringen. Kostenloses Erstgespräch — unverbindlich und konkret.
+        <p class="mt-3 text-base text-indigo-100">
+          Kostenloses Erstgespräch — unverbindlich und konkret.
         </p>
       </div>
       <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/layouts/partials/home/services.html
+++ b/layouts/partials/home/services.html
@@ -12,29 +12,52 @@
       <h2 class="text-3xl font-black capitalize tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl">
         Was wir Euch anbieten
       </h2>
-      <p class="mx-auto mt-3 max-w-2xl text-xl text-gray-500 dark:text-gray-300 sm:mt-4">
-        Von KI-Strategie und AI Agent-Entwicklung über Cloud-Infrastruktur bis zur Anwendungsentwicklung — modern, bewährt und zukunftssicher.
+      <p class="mx-auto mt-3 max-w-2xl text-lg text-gray-500 dark:text-gray-300 sm:mt-4">
+        Von KI-Strategie über Cloud-Infrastruktur bis zur Anwendungsentwicklung.
       </p>
     </div>
 
     <div class="mx-auto max-w-7xl text-gray-900 dark:text-gray-50">
       <div class="not-prose text-gray-900 dark:text-zinc-200">
-        <div class="mx-auto mt-12 mb-4 grid gap-5 md:grid-cols-2 lg:grid-cols-3 lg:max-w-none">
+        <div class="mx-auto mt-12 mb-4 grid items-start gap-5 md:grid-cols-2 lg:grid-cols-3 lg:max-w-none">
           {{ range $index, $skill := $.Site.Data.skills }}
-            <div class="group flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900">
-              <div class="flex items-center gap-4 border-b border-gray-100 px-6 pt-6 pb-4 dark:border-gray-800">
+            <div
+              x-data="{ open: false }"
+              class="group flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition duration-300 hover:shadow-lg dark:border-gray-700 dark:bg-gray-900"
+            >
+              <button
+                @click="open = !open"
+                class="flex w-full cursor-pointer items-center gap-4 px-6 py-5 text-left"
+              >
                 <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-md">
                   <i class="{{ .icon }} text-xl"></i>
                 </div>
-                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                <h3 class="flex-1 text-lg font-bold text-gray-900 dark:text-gray-100">
                   {{ .title }}
                 </h3>
-              </div>
-              <div class="flex flex-1 flex-col p-6">
-                <p class="mb-5 flex-1 text-base leading-relaxed text-gray-600 dark:text-gray-300">
+                <span
+                  class="inline-flex text-sm text-gray-400 transition-transform duration-300"
+                  :class="{ 'rotate-180': open }"
+                >
+                  <i class="fa-solid fa-chevron-down"></i>
+                </span>
+              </button>
+
+              <div
+                x-show="open"
+                x-cloak
+                x-transition:enter="transition duration-200 ease-out"
+                x-transition:enter-start="opacity-0 -translate-y-2"
+                x-transition:enter-end="opacity-100 translate-y-0"
+                x-transition:leave="transition duration-150 ease-in"
+                x-transition:leave-start="opacity-100 translate-y-0"
+                x-transition:leave-end="opacity-0 -translate-y-2"
+                class="border-t border-gray-100 px-6 pb-6 pt-4 dark:border-gray-800"
+              >
+                <p class="mb-4 text-sm leading-relaxed text-gray-600 dark:text-gray-300">
                   {{ .description }}
                 </p>
-                <div class="space-y-2 border-t border-gray-100 pt-4 dark:border-gray-800">
+                <div class="space-y-1.5">
                   {{ range (.tags) }}
                     <div class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
                       <i class="fa fa-check mt-0.5 shrink-0 text-indigo-500"></i>

--- a/layouts/partials/home/services.html
+++ b/layouts/partials/home/services.html
@@ -1,61 +1,45 @@
 <!-- Services -->
-<div
-  class="relative bg-transparent pt-8 pb-4 md:mt-12 lg:mb-4 lg:pt-12"
->
+<div id="services" class="relative bg-transparent pt-8 pb-4 md:mt-12 lg:mb-4 lg:pt-12">
   <div class="absolute inset-0">
     <div class="h-1/3 bg-gray-200 dark:bg-gray-900/50 sm:h-2/3"></div>
   </div>
   <div class="relative mx-auto max-w-7xl px-4">
     <div class="text-center">
-      <h2
-        class="text-3xl font-black capitalize tracking-tight text-indigo-500 dark:text-indigo-300 sm:text-4xl"
-      >
-        Was wir Euch anbieten?
+      <div class="mb-3 inline-flex items-center gap-2 rounded-full border border-indigo-500/20 bg-indigo-50 px-4 py-1.5 text-sm font-medium text-indigo-600 dark:border-indigo-400/20 dark:bg-indigo-500/10 dark:text-indigo-300">
+        <i class="fa-solid fa-sparkles"></i>
+        Unser Portfolio
+      </div>
+      <h2 class="text-3xl font-black capitalize tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl">
+        Was wir Euch anbieten
       </h2>
-      <p
-        class="mx-auto mt-3 max-w-2xl text-xl text-gray-500 dark:text-gray-300 sm:mt-4"
-      >
-        Wir bieten Euch ein fundiertes Paket über den kompletten Stack hinweg an
-        - ab der Konzeption über die Umsetzung der IT-Infrastruktur bis hin zur
-        Anwendungsentwicklung. Wir setzen dabei auf moderne, bewährte und
-        nachhaltige Methoden und Technologien &mdash; gerne auch cutting edge!
+      <p class="mx-auto mt-3 max-w-2xl text-xl text-gray-500 dark:text-gray-300 sm:mt-4">
+        Von KI-Strategie und AI Agent-Entwicklung über Cloud-Infrastruktur bis zur Anwendungsentwicklung — modern, bewährt und zukunftssicher.
       </p>
     </div>
 
     <div class="mx-auto max-w-7xl text-gray-900 dark:text-gray-50">
       <div class="not-prose text-gray-900 dark:text-zinc-200">
-        <div class="mx-auto mt-12 mb-4 grid gap-4 md:grid-cols-2 lg:max-w-none">
-          {{ range $.Site.Data.skills }}
-            <div
-              class="flex flex-col overflow-hidden rounded-lg bg-gray-50 shadow-lg dark:bg-gray-900"
-            >
-              <div
-                class="flex flex-col items-center overflow-hidden rounded-t-lg bg-indigo-500 object-fill dark:bg-indigo-600 "
-                width="100%"
-              >
-                <span class="icon p-6"
-                  ><i class="{{ .icon }} text-7xl"></i
-                ></span>
-              </div>
-              <div class="p-6">
-                <div class="flex-1">
-                  <span
-                    class="mt-2 block text-2xl font-black text-gray-900  dark:text-gray-200 "
-                  >
-                    {{ .title }}
-                  </span>
-                  <p class="mt-3 text-base text-gray-900 dark:text-gray-300">
-                    {{ .description }}
-                  </p>
+        <div class="mx-auto mt-12 mb-4 grid gap-5 md:grid-cols-2 lg:grid-cols-3 lg:max-w-none">
+          {{ range $index, $skill := $.Site.Data.skills }}
+            <div class="group flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900">
+              <div class="flex items-center gap-4 border-b border-gray-100 px-6 pt-6 pb-4 dark:border-gray-800">
+                <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-md">
+                  <i class="{{ .icon }} text-xl"></i>
                 </div>
-                <div class="text-md block pt-6 font-medium">
-                  <p class="pr-2 text-lg font-bold">Fokus</p>
-                  {{ range $elem_index, $elem_val := (.tags) }}
-                    {{- if gt
-                      $elem_index 0
-                    }}
-                    {{ end -}}
-                    <p><i class="fa fa-check pr-1"></i> {{ . }}</p>
+                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                  {{ .title }}
+                </h3>
+              </div>
+              <div class="flex flex-1 flex-col p-6">
+                <p class="mb-5 flex-1 text-base leading-relaxed text-gray-600 dark:text-gray-300">
+                  {{ .description }}
+                </p>
+                <div class="space-y-2 border-t border-gray-100 pt-4 dark:border-gray-800">
+                  {{ range (.tags) }}
+                    <div class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                      <i class="fa fa-check mt-0.5 shrink-0 text-indigo-500"></i>
+                      <span>{{ . }}</span>
+                    </div>
                   {{- end -}}
                 </div>
               </div>

--- a/layouts/partials/home/team.html
+++ b/layouts/partials/home/team.html
@@ -4,8 +4,8 @@
       <h2 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl">
         Die Gründer
       </h2>
-      <p class="mx-auto mt-3 max-w-2xl text-lg text-gray-600 dark:text-gray-300">
-        Gemeinsam über 15 Jahre Erfahrung in Softwareentwicklung, Cloud-Infrastruktur und KI.
+      <p class="mx-auto mt-2 max-w-2xl text-base text-gray-500 dark:text-gray-400">
+        15+ Jahre Erfahrung in Software, Cloud & KI.
       </p>
     </div>
     <div class="not-prose">

--- a/layouts/partials/home/team.html
+++ b/layouts/partials/home/team.html
@@ -1,27 +1,31 @@
-<div id="team" class="team">
-  <div class="mx-auto max-w-7xl text-gray-900 dark:text-gray-50">
-    <div class="not-prose px-4 text-gray-900 ">
-      <div
-        class="mx-auto mt-6 mb-6 grid gap-4 pb-6 md:grid-cols-2 lg:max-w-none"
-      >
+<div id="team" class="team bg-gray-100 py-12 dark:bg-gray-900">
+  <div class="mx-auto max-w-7xl px-4">
+    <div class="mb-8 text-center">
+      <h2 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-50 sm:text-4xl">
+        Die Gründer
+      </h2>
+      <p class="mx-auto mt-3 max-w-2xl text-lg text-gray-600 dark:text-gray-300">
+        Gemeinsam über 15 Jahre Erfahrung in Softwareentwicklung, Cloud-Infrastruktur und KI.
+      </p>
+    </div>
+    <div class="not-prose">
+      <div class="mx-auto grid gap-6 md:grid-cols-2 lg:max-w-4xl">
         {{ range $.Site.Data.founders }}
-          <div
-            class="member flex flex-col items-start rounded-md bg-gray-50 p-7 text-gray-900 shadow-lg duration-200 hover:-translate-y-2  dark:bg-gray-800 dark:text-zinc-200 sm:flex-row"
-          >
-            <div class="sm:flex-start shrink-0 self-center pr-8 sm:min-w-fit">
+          <div class="member flex flex-col items-start rounded-xl border border-gray-200 bg-white p-7 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 sm:flex-row">
+            <div class="shrink-0 self-center pr-6 sm:min-w-fit">
               <img
                 src="{{ ((resources.GetMatch .image ).Resize "500x webp").RelPermalink }}"
-                alt="Founder image: {{ .name }}"
-                class="h-full max-h-44 rounded-full"
+                alt="{{ .name }}"
+                class="h-full max-h-40 rounded-full ring-2 ring-indigo-500/20"
               />
             </div>
             <div>
               <h4 class="mb-1 text-xl font-bold text-indigo-500">
                 {{ .name }}
               </h4>
-              <span class="text-sm font-medium">{{ .position }}</span>
-              <hr class="my-2" />
-              <p class="text-sm">
+              <span class="text-sm font-semibold text-gray-500 dark:text-gray-400">{{ .position }}</span>
+              <hr class="my-2 border-gray-200 dark:border-gray-700" />
+              <p class="text-sm text-gray-700 dark:text-gray-300">
                 {{ .description }}
               </p>
               <div class="social mt-3 flex space-x-2">

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,6 +1,6 @@
 <title itemprop="name">
   {{ if .IsHome }}
-    {{ $.Site.Params.description }} |
+    {{ with $.Site.Params.homeTitle }}{{ . }}{{ else }}{{ $.Site.Params.description }}{{ end }} |
     {{ .Title }}
   {{ else }}
     {{ .Title }} |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  hugo-bin: true


### PR DESCRIPTION
- Dark hero with gradient text, dual CTAs, highlight cards
- Add 3 AI services: Guidance, Workshops (ChatGPT/Claude/Copilot/Cursor/v0), Agents & MCP
- Redesign service cards (3-col grid, icon badges, hover effects)
- Update team section with heading, Geschäftsführer titles
- Gradient CTA section with free consultation offer
- SEO: descriptive meta, clean page title
- CSS: grid pattern, animated gradient text