### PR TITLE
fix(build): Hugo PostCSS under pnpm + Node permissions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,11 +29,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6.0.9
         with:
-          version: latest
+          version: 11
 
       - uses: actions/setup-node@v7.0.0
         with:
-          node-version: lts/*
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -106,3 +106,20 @@ menu:
       post: "AI Knowledge Bots"
       url: "https://crbnai.com"
       weight: 20
+
+# Hugo ≥0.161 runs PostCSS under Node --permission. Tailwind v4 needs native
+# addons (lightningcss) when the executed tool is `postcss`.
+security:
+  node:
+    permissions:
+      allowAddons:
+        - postcss
+        - tailwindcss
+      allowChildProcess:
+        - postcss
+        - tailwindcss
+      allowRead:
+        - "."
+      allowWorker:
+        - postcss
+        - tailwindcss

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "build": "hugo --minify",
     "clean": "rimraf public/",
     "dev": "hugo server",
-    "start": "pnpm dev"
+    "start": "pnpm dev",
+    "fix:postcss-bin": "node scripts/fix-postcss-bin.mjs",
+    "postinstall": "node scripts/fix-postcss-bin.mjs",
+    "prebuild": "node scripts/fix-postcss-bin.mjs"
   },
   "hugo-bin": {
     "buildTags": "extended"

--- a/scripts/fix-postcss-bin.mjs
+++ b/scripts/fix-postcss-bin.mjs
@@ -1,0 +1,25 @@
+// Hugo requires `postcss` to be a Node.js script (checks shebang).
+// pnpm installs a POSIX shell shim in node_modules/.bin/postcss, which Hugo rejects.
+// Copying postcss-cli/index.js breaks relative imports (./lib/...), so write a thin
+// wrapper that re-exports the real CLI entry.
+import { chmodSync, existsSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(root, "node_modules", "postcss-cli", "index.js");
+const dest = join(root, "node_modules", ".bin", "postcss");
+
+if (!existsSync(cli)) {
+  console.warn("fix-postcss-bin: postcss-cli missing, skip");
+  process.exit(0);
+}
+
+writeFileSync(
+  dest,
+  `#!/usr/bin/env node
+import "../postcss-cli/index.js";
+`,
+);
+chmodSync(dest, 0o755);
+console.log("fix-postcss-bin: installed Node postcss bin for Hugo");


### PR DESCRIPTION
## Summary
- Main Build & Deploy broken after hugo-bin 0.161: Hugo rejects pnpm shell shim for `postcss`, and Tailwind v4 needs native addon perms when tool is `postcss`.
- Add `scripts/fix-postcss-bin.mjs` (postinstall/prebuild) writing a real Node wrapper in `node_modules/.bin/postcss`.
- Allow `postcss` (and tailwindcss) under `security.node.permissions`.
- Pin CI to Node 22 + pnpm 11.

## Test plan
- [ ] PR Build & Deploy green
- [ ] Merge → main deploy green